### PR TITLE
feat: Add search functionality to daily-focus and use-cases pages

### DIFF
--- a/daily-focus/index.html
+++ b/daily-focus/index.html
@@ -74,6 +74,11 @@
             <h1 class="text-3xl md:text-4xl font-bold text-gray-900">Daily Sourcing Focus</h1>
         </header>
 
+        <!-- Search Bar -->
+        <div class="mb-6 max-w-lg mx-auto">
+            <input type="search" id="search-input" placeholder="Search focus cards by keyword..." class="w-full p-3 border border-gray-300 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500">
+        </div>
+
         <!-- Card of the Day Section -->
         <section id="card-of-the-day-section" class="mb-10">
             <h2 class="text-2xl font-bold text-center text-indigo-700 mb-4">Today's Focus</h2>
@@ -131,6 +136,7 @@
         const prevBtn = document.getElementById('prev-btn');
         const nextBtn = document.getElementById('next-btn');
         const cardCounter = document.getElementById('card-counter');
+        const searchInput = document.getElementById('search-input');
 
         // --- State Management ---
         function initializeData(focusPointsData) {
@@ -271,19 +277,35 @@
         }
 
         // --- Deck Management for Library ---
-        function loadDeck(category = 'All') {
-            currentDeck = (category === 'All') ? [...focusPoints] : focusPoints.filter(p => p.category === category);
+        function updateDeck() {
+            const activeCategory = document.querySelector('.filter-button.active')?.dataset.category || 'All';
+            const searchTerm = searchInput.value.toLowerCase().trim();
+
+            const categoryFiltered = (activeCategory === 'All')
+                ? [...focusPoints]
+                : focusPoints.filter(p => p.category === activeCategory);
+
+            if (searchTerm) {
+                currentDeck = categoryFiltered.filter(p => {
+                    const searchableText = `${p.title} ${p.quote} ${p.actions.join(' ')}`.toLowerCase();
+                    return searchableText.includes(searchTerm);
+                });
+            } else {
+                currentDeck = categoryFiltered;
+            }
+
             currentIndex = 0;
             showCardInLibrary(currentIndex);
-            updateActiveFilterButton(category);
+            updateActiveFilterButton(activeCategory);
         }
 
         function showCardInLibrary(index) {
             cardContainer.innerHTML = '';
 
             if (!currentDeck || currentDeck.length === 0) {
-                cardContainer.innerHTML = `<div class="text-center text-gray-500 p-8 bg-white rounded-xl shadow-md"><h3>No items in this category.</h3></div>`;
+                cardContainer.innerHTML = `<div class="text-center text-gray-500 p-8 bg-white rounded-xl shadow-md"><h3>No matching cards found.</h3><p>Try adjusting your search or filter.</p></div>`;
                 cardNavigation.style.display = 'none';
+                cardCounter.textContent = "0 / 0";
                 return;
             }
 
@@ -308,7 +330,10 @@
                 button.textContent = `${category} (${count})`;
                 button.className = 'filter-button px-3 py-1.5 text-sm font-medium rounded-full bg-white text-gray-700 shadow-sm hover:bg-gray-200 transition-colors';
                 button.dataset.category = category;
-                button.addEventListener('click', () => loadDeck(category));
+                button.addEventListener('click', () => {
+                    updateActiveFilterButton(category);
+                    updateDeck();
+                });
                 categoryFiltersContainer.appendChild(button);
             });
         }
@@ -327,9 +352,11 @@
                     initializeData(data);
                     renderCardOfTheDay();
                     populateFilters();
-                    loadDeck('All');
+                    updateDeck(); // Initial deck load
                 })
                 .catch(error => console.error('Error fetching focus points:', error));
+
+            searchInput.addEventListener('input', updateDeck);
 
             prevBtn.addEventListener('click', () => {
                 if (currentIndex > 0) {

--- a/use-cases/index.html
+++ b/use-cases/index.html
@@ -51,6 +51,11 @@
         </header>
 
         <main>
+            <!-- Search Bar -->
+            <div class="mb-8 max-w-lg mx-auto">
+                <input type="search" id="use-case-search" placeholder="Search success stories by keyword..." class="w-full p-3 border border-gray-300 rounded-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500">
+            </div>
+
             <!-- Filter Categories -->
             <div id="filters" class="flex flex-wrap justify-center gap-3 mb-12">
                 <button data-filter="all" class="category-filter active px-4 py-2 rounded-full text-sm font-medium transition-colors duration-200">All Stories</button>
@@ -313,6 +318,12 @@
 
             </div>
 
+            <!-- No Results Message -->
+            <div id="no-results-message" class="text-center py-16 hidden">
+                <h3 class="text-xl font-semibold text-gray-700">No matching success stories found</h3>
+                <p class="text-gray-500 mt-2">Please try adjusting your search or filter criteria.</p>
+            </div>
+
             <!-- Interactive Demo Section -->
             <div id="demo-section" class="demo-section mt-16 p-8 rounded-xl hidden">
                 <div class="max-w-4xl mx-auto">
@@ -498,23 +509,31 @@ Requirements:
             if (result) result.classList.remove('hidden');
         }
 
-        // Filter functionality (no inline 'event' usage)
-        function filterCases(category, targetButton) {
+        // Combined filter and search functionality
+        function runFilters() {
+            const activeCategory = document.querySelector('.category-filter.active')?.dataset.filter || 'all';
+            const searchTerm = document.getElementById('use-case-search').value.toLowerCase().trim();
             const cases = document.querySelectorAll('.case-item');
-            const filters = document.querySelectorAll('.category-filter');
+            let visibleCount = 0;
 
-            // Update active filter classes
-            filters.forEach(f => f.classList.remove('active'));
-            if (targetButton) targetButton.classList.add('active');
-
-            // Show/hide cases
             cases.forEach(c => {
-                if (category === 'all' || c.dataset.category === category) {
+                const categoryMatch = activeCategory === 'all' || c.dataset.category === activeCategory;
+                const textContent = c.textContent.toLowerCase();
+                const searchMatch = !searchTerm || textContent.includes(searchTerm);
+
+                if (categoryMatch && searchMatch) {
                     c.style.display = '';
+                    visibleCount++;
                 } else {
                     c.style.display = 'none';
                 }
             });
+
+            // Optional: Show a message if no results found
+            const noResultsMessage = document.getElementById('no-results-message');
+            if (noResultsMessage) {
+                noResultsMessage.style.display = visibleCount === 0 ? 'block' : 'none';
+            }
         }
 
         // DOM ready
@@ -529,14 +548,20 @@ Requirements:
             `;
             document.head.appendChild(style);
 
-            // Wire filter buttons
+            const searchInput = document.getElementById('use-case-search');
             const filterButtons = document.querySelectorAll('#filters .category-filter');
+
+            // Wire filter buttons
             filterButtons.forEach(btn => {
                 btn.addEventListener('click', () => {
-                    const cat = btn.getAttribute('data-filter') || 'all';
-                    filterCases(cat, btn);
+                    filterButtons.forEach(f => f.classList.remove('active'));
+                    btn.classList.add('active');
+                    runFilters();
                 });
             });
+
+            // Wire search input
+            searchInput.addEventListener('input', runFilters);
 
             // Wire demo buttons
             const demoButtons = document.querySelectorAll('.demo-btn');


### PR DESCRIPTION
This commit addresses the findings from the search audit by implementing local search features on pages that were missing them.

- **daily-focus/index.html**:
  - Added a search bar to the page.
  - Implemented client-side JavaScript to filter the "focus cards" based on a user's search query. The search filters by card title, quote, and action items.
  - Ensured the search works in conjunction with the existing category filters.

- **use-cases/index.html**:
  - Added a search bar to the page.
  - Implemented client-side JavaScript to filter the success story cards based on a user's search query.
  - The search and category filters now work together, allowing users to refine results by both category and keyword.
  - Added a "no results" message for a better user experience.