### PR TITLE
feat: Add consistent 'Back To Hub' button to Use Cases

### DIFF
--- a/shared/hub-button.css
+++ b/shared/hub-button.css
@@ -1,26 +1,19 @@
 .hub-button {
-  position: fixed;
-  top: 20px;
-  left: 20px;
-  background-color: #4A90E2;
-  color: white;
-  padding: 10px 20px;
-  border-radius: 50px;
-  text-decoration: none;
-  font-family: sans-serif;
-  font-weight: bold;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  transition: all 0.3s ease;
-  z-index: 1000;
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    background-color: #4A90E2;
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+    text-decoration: none;
+    font-weight: 500;
+    z-index: 50;
+    transition: background-color 0.2s ease;
 }
 
 .hub-button:hover {
-  background-color: #357ABD;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
-  transform: translateY(-2px);
-}
-
-.hub-button-right {
-  left: auto;
-  right: 20px;
+    background-color: #3a7bc8;
+    color: white;
 }

--- a/use-cases/index.html
+++ b/use-cases/index.html
@@ -19,13 +19,12 @@
     </style>
 </head>
 <body class="bg-gray-50 text-gray-800">
-
+    <a href="/index.html" class="hub-button">Back To Hub</a>
     <!-- Navigation -->
     <nav class="bg-white border-b border-gray-200">
         <div class="container mx-auto px-4 py-4">
             <div class="flex items-center justify-between">
                 <a href="/" class="google-sans text-xl font-bold text-gray-900">Randstad GBS Learning Hub</a>
-                <a href="/" class="text-sm text-gray-600 hover:text-blue-600 transition-colors duration-200">← Back to Hub</a>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
This commit adds a fixed-position "Back To Hub" button to the `use-cases/index.html` page to ensure consistent navigation across the site.

- Updates `shared/hub-button.css` with the standard modern styles for the button, including `rem` units, a proper box-shadow, and hover effects.
- Modifies `use-cases/index.html` to include the new button.
- Removes the old, text-based "Back to Hub" link from the navigation bar to avoid redundancy.