### PR TITLE
feat: Implement Quick-Start Onboarding Tour

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link
         href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500&display=swap"
         rel="stylesheet">
+    <link rel="stylesheet" href="tour.css">
     <style>
         .google-sans {
             font-family: 'Google Sans', sans-serif;
@@ -350,6 +351,30 @@
     </div>
 
     <div id="footer-placeholder"></div>
+
+    <!-- Replay Tour Button Container -->
+    <div class="text-center py-4">
+        <button id="replay-tour-btn">Replay Onboarding Tour</button>
+    </div>
+
+    <!-- Tour HTML Structure -->
+    <div class="tour-overlay"></div>
+    <div class="tour-highlight"></div>
+    <div class="tour-popover">
+        <div class="tour-popover-arrow"></div>
+        <div class="tour-popover-content">
+            <h3 class="tour-popover-title"></h3>
+            <p></p>
+        </div>
+        <div class="tour-navigation">
+            <span class="tour-progress"></span>
+            <div class="tour-buttons">
+                <button class="tour-btn tour-btn-skip">Skip</button>
+                <button class="tour-btn tour-btn-next">Next</button>
+            </div>
+        </div>
+    </div>
+
     <script src="shared/scripts/footer.js" defer></script>
 
     <script>
@@ -833,6 +858,7 @@
             });
         });
     </script>
+    <script src="tour.js"></script>
 </body>
 
 </html>

--- a/tour.css
+++ b/tour.css
@@ -1,0 +1,154 @@
+/* Tour Overlay */
+.tour-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.tour-overlay.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+/* Highlighted Element */
+.tour-highlight {
+    position: absolute;
+    border-radius: 4px;
+    box-shadow: 0 0 0 4px rgba(74, 144, 226, 0.7), 0 0 20px rgba(74, 144, 226, 0.5);
+    transition: all 0.3s ease-in-out;
+    z-index: 1001;
+    pointer-events: none;
+}
+
+/* Tour Popover */
+.tour-popover {
+    position: absolute;
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+    width: 320px;
+    max-width: 90vw;
+    z-index: 1002;
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    padding: 20px;
+    font-family: 'Roboto', sans-serif;
+}
+
+.tour-popover.active {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.tour-popover-content {
+    font-size: 16px;
+    line-height: 1.6;
+    color: #374151;
+}
+
+.tour-popover-title {
+    font-family: 'Google Sans', sans-serif;
+    font-size: 20px;
+    font-weight: 700;
+    color: #1967d2;
+    margin-bottom: 12px;
+}
+
+/* Popover Arrow */
+.tour-popover-arrow {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    background: white;
+    transform: rotate(45deg);
+}
+
+/* Popover placement classes */
+.tour-popover[data-placement^="bottom"] .tour-popover-arrow {
+    top: -6px;
+    left: 50%;
+    margin-left: -6px;
+}
+.tour-popover[data-placement^="top"] .tour-popover-arrow {
+    bottom: -6px;
+    left: 50%;
+    margin-left: -6px;
+}
+.tour-popover[data-placement^="left"] .tour-popover-arrow {
+    right: -6px;
+    top: 50%;
+    margin-top: -6px;
+}
+.tour-popover[data-placement^="right"] .tour-popover-arrow {
+    left: -6px;
+    top: 50%;
+    margin-top: -6px;
+}
+
+/* Tour Navigation */
+.tour-navigation {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid #e5e7eb;
+}
+
+.tour-progress {
+    font-size: 14px;
+    color: #6b7280;
+}
+
+.tour-buttons {
+    display: flex;
+    gap: 8px;
+}
+
+.tour-btn {
+    background-color: transparent;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 500;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.tour-btn-skip {
+    color: #6b7280;
+}
+.tour-btn-skip:hover {
+    background-color: #f3f4f6;
+}
+
+.tour-btn-next {
+    background-color: #1967d2;
+    color: white;
+}
+.tour-btn-next:hover {
+    background-color: #175ab3;
+}
+
+/* Replay Tour Button */
+#replay-tour-btn {
+    background: none;
+    border: none;
+    color: #4A90E2;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 8px;
+    border-radius: 4px;
+}
+#replay-tour-btn:hover {
+    text-decoration: underline;
+    background-color: rgba(74, 144, 226, 0.1);
+}

--- a/tour.js
+++ b/tour.js
@@ -1,0 +1,193 @@
+class Tour {
+    constructor() {
+        this.tourOverlay = document.querySelector('.tour-overlay');
+        this.tourHighlight = document.querySelector('.tour-highlight');
+        this.tourPopover = document.querySelector('.tour-popover');
+        this.replayBtn = document.getElementById('replay-tour-btn');
+
+        this.currentStep = -1;
+        this.steps = [
+            {
+                selector: 'header h1',
+                title: 'Welcome to the Learning Hub!',
+                description: 'This is your central portal for AI training, tools, and resources. Let\'s take a quick 30-second tour of the key features.',
+                placement: 'bottom'
+            },
+            {
+                selector: '#global-search',
+                title: 'Universal Search',
+                description: 'Use this powerful search bar to find anything you need across all modules, from specific lessons to prompt examples.',
+                placement: 'bottom'
+            },
+            {
+                selector: 'a[href="/gbs-prompts/"]',
+                title: 'GBS AI Prompts Library',
+                description: 'Access a comprehensive library of expert-crafted prompts to accelerate your daily tasks and projects.',
+                placement: 'top'
+            },
+            {
+                selector: 'a[href="/daily-focus/"]',
+                title: 'Daily Sourcing Focus',
+                description: 'Sharpen your skills with this micro-coaching tool, offering daily actionable cards for talent sourcers.',
+                placement: 'top'
+            },
+            {
+                selector: '.hub-button, .back-to-hub-btn', // Generic selector for back button
+                title: 'Return to Hub',
+                description: 'Whenever you\'re in a sub-module, look for a "Back to Hub" button to easily return to this main page.',
+                placement: 'bottom-start'
+            },
+            {
+                selector: '#replay-tour-btn',
+                title: 'Tour Complete!',
+                description: 'You can retake this tour anytime by clicking this button. Enjoy exploring the Learning Hub!',
+                placement: 'top'
+            }
+        ];
+    }
+
+    init() {
+        this.tourPopover.querySelector('.tour-btn-next').addEventListener('click', () => this.nextStep());
+        this.tourPopover.querySelector('.tour-btn-skip').addEventListener('click', () => this.endTour());
+        this.tourOverlay.addEventListener('click', () => this.endTour());
+        this.replayBtn.addEventListener('click', () => this.startTour(true));
+
+        window.addEventListener('keydown', (e) => {
+            if (!this.tourOverlay.classList.contains('active')) return;
+            if (e.key === 'Escape') this.endTour();
+            if (e.key === 'ArrowRight') this.nextStep();
+            if (e.key === 'ArrowLeft') this.prevStep();
+        });
+
+        // Auto-start for first-time visitors
+        if (!localStorage.getItem('gbsHubTourCompleted')) {
+            setTimeout(() => this.startTour(), 500);
+        }
+    }
+
+    startTour(force = false) {
+        if (!force && localStorage.getItem('gbsHubTourCompleted')) return;
+
+        this.currentStep = -1;
+        this.tourOverlay.classList.add('active');
+        document.body.style.overflow = 'hidden';
+        this.nextStep();
+    }
+
+    nextStep() {
+        this.currentStep++;
+        if (this.currentStep >= this.steps.length) {
+            this.endTour();
+            return;
+        }
+        this.showStep(this.currentStep);
+    }
+
+    prevStep() {
+        this.currentStep--;
+        if (this.currentStep < 0) {
+            this.endTour();
+            return;
+        }
+        this.showStep(this.currentStep);
+    }
+
+    showStep(index) {
+        const step = this.steps[index];
+        const targetElement = document.querySelector(step.selector);
+
+        if (!targetElement) {
+            // If element not found, try the next one or end tour
+            this.nextStep();
+            return;
+        }
+
+        // Update popover content
+        this.tourPopover.querySelector('.tour-popover-title').textContent = step.title;
+        this.tourPopover.querySelector('p').textContent = step.description;
+        this.tourPopover.querySelector('.tour-progress').textContent = `${index + 1} / ${this.steps.length}`;
+
+        const nextBtn = this.tourPopover.querySelector('.tour-btn-next');
+        if (index === this.steps.length - 1) {
+            nextBtn.textContent = 'Finish';
+        } else {
+            nextBtn.textContent = 'Next';
+        }
+
+        // Position highlight and popover
+        const rect = targetElement.getBoundingClientRect();
+
+        this.tourHighlight.style.width = `${rect.width + 8}px`;
+        this.tourHighlight.style.height = `${rect.height + 8}px`;
+        this.tourHighlight.style.top = `${rect.top - 4 + window.scrollY}px`;
+        this.tourHighlight.style.left = `${rect.left - 4 + window.scrollX}px`;
+
+        this.tourPopover.classList.add('active');
+        this.positionPopover(targetElement, step.placement);
+
+        targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    positionPopover(target, placement) {
+        const targetRect = target.getBoundingClientRect();
+        const popoverRect = this.tourPopover.getBoundingClientRect();
+        const arrow = this.tourPopover.querySelector('.tour-popover-arrow');
+        let top, left;
+
+        const offset = 12; // Distance between popover and highlight
+
+        switch (placement) {
+            case 'top':
+                top = targetRect.top - popoverRect.height - offset;
+                left = targetRect.left + (targetRect.width / 2) - (popoverRect.width / 2);
+                break;
+            case 'bottom':
+                top = targetRect.bottom + offset;
+                left = targetRect.left + (targetRect.width / 2) - (popoverRect.width / 2);
+                break;
+            case 'left':
+                top = targetRect.top + (targetRect.height / 2) - (popoverRect.height / 2);
+                left = targetRect.left - popoverRect.width - offset;
+                break;
+            case 'right':
+                top = targetRect.top + (targetRect.height / 2) - (popoverRect.height / 2);
+                left = targetRect.right + offset;
+                break;
+             case 'bottom-start':
+                top = targetRect.bottom + offset;
+                left = targetRect.left;
+                break;
+        }
+
+        // Adjust for screen boundaries
+        if (left < 10) left = 10;
+        if ((left + popoverRect.width) > window.innerWidth - 10) {
+            left = window.innerWidth - popoverRect.width - 10;
+        }
+        if (top < 10) top = 10;
+        if ((top + popoverRect.height) > window.innerHeight - 10) {
+            top = window.innerHeight - popoverRect.height - 10;
+        }
+
+        this.tourPopover.style.top = `${top + window.scrollY}px`;
+        this.tourPopover.style.left = `${left + window.scrollX}px`;
+        this.tourPopover.dataset.placement = placement;
+    }
+
+
+    endTour() {
+        this.tourOverlay.classList.remove('active');
+        this.tourPopover.classList.remove('active');
+        this.tourHighlight.style.width = '0'; // Hide highlight
+        document.body.style.overflow = '';
+        localStorage.setItem('gbsHubTourCompleted', 'true');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    // A small delay to ensure all elements are rendered, especially from other scripts
+    setTimeout(() => {
+        const tour = new Tour();
+        tour.init();
+    }, 100);
+});


### PR DESCRIPTION
Adds a guided tour for first-time users to the main hub page.

The tour highlights key features like the global search and important navigation cards. It uses `localStorage` to detect first-time visitors and prevents the tour from showing automatically on subsequent visits.

A "Replay Tour" button is included for users who want to see the tour again. The implementation uses vanilla JavaScript and CSS for a lightweight solution, creating `tour.js` and `tour.css` to encapsulate the tour's logic and styling.