### PR TITLE
feat: Complete and standardize RPO training pathway pages

### DIFF
--- a/rpo-training/pathways/README.md
+++ b/rpo-training/pathways/README.md
@@ -1,0 +1,50 @@
+# RPO Training Pathway Pages
+
+This document outlines the structure of the role-based training pathway pages and provides instructions for maintaining and extending them.
+
+## Page Structure
+
+Each pathway page (e.g., `recruiter.html`, `manager.html`) is built from a consistent HTML template to ensure a uniform look and feel across the site. The key components of this template are:
+
+- **Shared Header:** The header is consistent with the main RPO Training Hub and provides a "Back to Hub" link.
+- **Breadcrumb Navigation:** Allows users to easily navigate back to the main Training Hub.
+- **Pathway Header:** A large, descriptive header that clearly identifies the learning pathway.
+- **Core Modules Section:** A grid of cards showcasing the key learning modules for the specific role.
+- **Learning Objectives Section:** A bulleted list detailing the skills and knowledge a user will gain.
+- **Tools & Resources Section:** Links to role-specific resources like cheat sheets, templates, and prompt libraries.
+- **Shared Footer & Scripts:** The standard site footer and JavaScript files for features like the "Back to Top" button are loaded dynamically.
+
+## Styling
+
+The pages are styled using a combination of:
+
+1.  **Tailwind CSS:** For utility-first styling and responsive design.
+2.  **Shared Stylesheets:** Located in `/shared/`, these files provide consistent typography (`fonts.css`), button styles (`buttons.css`), and other common elements.
+3.  **Pathway-Specific Stylesheet:** `rpo-training/pathways/css/pathways.css` contains styles specific to the pathway pages, such as the page header and module card customizations.
+
+## How to Add a New Pathway Page
+
+To add a new role-based pathway page (e.g., "Sourcer"), follow these steps:
+
+1.  **Create a New HTML File:** Create a new `.html` file in the `rpo-training/pathways/` directory (e.g., `sourcer.html`).
+2.  **Copy an Existing Page:** Copy the entire content of an existing pathway page (like `recruiter.html`) into your new file. This will serve as your template.
+3.  **Update the Head Section:**
+    -   Change the `<title>` to reflect the new role (e.g., "Sourcer Pathway - RPO AI Acceleration").
+4.  **Update Breadcrumb Navigation:**
+    -   Modify the breadcrumb text to match the new role (e.g., `<span>Sourcer Pathway</span>`).
+5.  **Customize the Page Content:**
+    -   **Pathway Header:** Update the `<h1>` and the descriptive paragraph for the new role.
+    -   **Core Modules:** Change the titles, descriptions, and color highlights (`text-green-600`, `text-blue-600`, etc.) for the modules.
+    -   **Learning Objectives:** Write new objectives tailored to the sourcer role.
+    -   **Tools & Resources:** Update the resource links and descriptions.
+6.  **Link from the Main Page:**
+    -   Open `rpo-training/index.html`.
+    -   Add a new button in the "Role-Specific Learning Tracks" section that links to your new page (e.g., `onclick="startRolePath('sourcer')"`).
+    -   Update the `startRolePath` function in `rpo-training/index.html` to include a case for the new role, directing it to your new file (`case 'sourcer': window.location.href = 'pathways/sourcer.html'; break;`).
+
+## Maintaining Consistency
+
+-   **Use the Template:** Always start new pages by copying an existing one to ensure all necessary CSS and JS files are included.
+-   **Leverage Existing Styles:** Before writing new CSS, check if Tailwind CSS or the shared stylesheets already provide the style you need.
+-   **Follow the Structure:** Maintain the existing content structure (Header, Modules, Objectives, Resources) to ensure a consistent user experience.
+-   **Keep Content Concise:** Use clear and concise language for all titles, descriptions, and objectives.

--- a/rpo-training/pathways/analyst.html
+++ b/rpo-training/pathways/analyst.html
@@ -1,69 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Analyst Learning Track - RPO Training Hub</title>
-    <link rel="stylesheet" href="../styles.css">
+    <title>Analyst Pathway - RPO AI Acceleration</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../../shared/hub-button.css">
+    <link rel="stylesheet" href="../../shared/fonts.css">
+    <link rel="stylesheet" href="../../shared/scroll-to-top.css">
+    <link rel="stylesheet" href="../../shared/buttons.css">
+    <link rel="stylesheet" href="../css/pathways.css">
+    <link rel="stylesheet" href="../../rpo-training/css/style.css">
 </head>
-<body>
-    <div class="container">
-        <header>
-            <h1>📊 Analyst Learning Track</h1>
-            <p class="subtitle">Data-driven AI training for recruitment analysts</p>
-        </header>
 
-        <div class="role-welcome">
-            <div class="welcome-card">
-                <h2>Welcome, Analyst!</h2>
-                <p>As a recruitment analyst, you'll benefit most from our <strong>Intermediate Learning Path</strong>, with additional focus on data analysis, reporting, and AI-powered insights for recruitment metrics.</p>
-            </div>
+<body class="text-gray-800">
 
-            <div class="recommended-modules">
-                <h3>🌟 Recommended Focus Areas</h3>
-                <div class="module-grid">
-                    <div class="module-card highlight">
-                        <h4>Data Analysis with AI</h4>
-                        <p>Learn to analyze recruitment data, identify trends, and generate insights</p>
-                    </div>
-                    <div class="module-card highlight">
-                        <h4>Automated Reporting</h4>
-                        <p>Create dynamic reports and dashboards using AI assistance</p>
-                    </div>
-                    <div class="module-card highlight">
-                        <h4>Predictive Analytics</h4>
-                        <p>Use AI for forecasting hiring needs and candidate success rates</p>
-                    </div>
+    <!-- Header -->
+    <header class="bg-white site-header sticky top-0 z-10">
+        <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+            <h1 id="header-title" class="google-sans text-2xl text-gray-700">RPO AI Acceleration Program</h1>
+            <a href="../../index.html" class="hub-button">Back To Hub</a>
+        </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="max-w-5xl mx-auto px-6 py-8">
+
+        <!-- Breadcrumb Navigation -->
+        <div class="breadcrumb-nav">
+            <a href="../index.html">Training Hub</a>
+            <span class="separator">&gt;</span>
+            <span>Analyst Pathway</span>
+        </div>
+
+        <!-- Page Header -->
+        <div class="pathway-header">
+            <h1 class="google-sans text-4xl font-bold text-gray-800">📈 Analyst Learning Pathway</h1>
+            <p class="mt-4 text-lg text-gray-600">Leverage AI for data analysis, reporting, and generating insights to drive data-driven recruitment strategies.</p>
+        </div>
+
+        <!-- Learning Modules Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Core Modules</h2>
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <!-- Module 1 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-cyan-600">MODULE 1</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Data Analysis with AI</h3>
+                    <p class="mt-2 text-gray-600">Learn to analyze recruitment data, identify trends, and generate actionable insights with AI-powered tools.</p>
+                </div>
+                <!-- Module 2 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-cyan-600">MODULE 2</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Automated Reporting</h3>
+                    <p class="mt-2 text-gray-600">Create dynamic, real-time reports and dashboards to visualize key recruitment metrics.</p>
+                </div>
+                <!-- Module 3 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-cyan-600">MODULE 3</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Predictive Analytics</h3>
+                    <p class="mt-2 text-gray-600">Use AI for forecasting hiring needs, predicting candidate success, and optimizing talent pipelines.</p>
                 </div>
             </div>
+        </section>
 
-            <div class="pathway-redirect">
-                <h3>🚀 Ready to Analyze?</h3>
-                <p>You'll be directed to the Intermediate Learning Path with analyst-specific examples and data-focused use cases.</p>
-                <button onclick="startAnalystPath()" class="cta-button">Begin Analyst Training</button>
+        <!-- Learning Objectives Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Learning Objectives</h2>
+            <ul class="list-disc list-inside space-y-2 text-gray-700">
+                <li>Automate the process of cleaning and analyzing recruitment data.</li>
+                <li>Generate custom reports and data visualizations using AI prompts.</li>
+                <li>Identify key trends and provide actionable insights to leadership.</li>
+                <li>Build predictive models for key recruitment metrics like time-to-hire.</li>
+            </ul>
+        </section>
+
+        <!-- Resources Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Tools & Resources</h2>
+            <div class="grid md:grid-cols-2 gap-6">
+                <a href="#" class="resource-card bg-white p-4 rounded-lg border border-gray-200 hover:shadow-md transition-shadow">
+                    <h4 class="font-bold text-cyan-700">Data Analysis Prompt Library</h4>
+                    <p class="text-sm text-gray-600">A collection of prompts for analyzing recruitment data sets.</p>
+                </a>
+                <a href="#" class="resource-card bg-white p-4 rounded-lg border border-gray-200 hover:shadow-md transition-shadow">
+                    <h4 class="font-bold text-cyan-700">AI Reporting Cheatsheet</h4>
+                    <p class="text-sm text-gray-600">A guide to building automated reports with popular AI tools.</p>
+                </a>
             </div>
-        </div>
-    </div>
+        </section>
 
-    <script>
-        function startAnalystPath() {
-            // Set role-specific context
-            localStorage.setItem('userRole', 'analyst');
-            localStorage.setItem('roleSpecificFocus', JSON.stringify([
-                'data-analysis',
-                'reporting-automation',
-                'predictive-analytics',
-                'metrics-optimization'
-            ]));
-            
-            // Redirect to intermediate path
-            window.location.href = 'intermediate.html';
-        }
+    </main>
 
-        // Auto-redirect after 5 seconds if user doesn't click
-        setTimeout(() => {
-            startAnalystPath();
-        }, 5000);
-    </script>
+    <!-- Back to Top Button -->
+    <button id="back-to-top" class="back-to-top" title="Back to top" aria-label="Scroll to top">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6" /></svg>
+    </button>
+
+    <div id="footer-placeholder"></div>
+    <script src="../../shared/scripts/footer.js" defer></script>
+    <script src="../../shared/scripts/scroll-to-top.js" defer></script>
 </body>
 </html>

--- a/rpo-training/pathways/coordinator.html
+++ b/rpo-training/pathways/coordinator.html
@@ -1,69 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Coordinator Learning Track - RPO Training Hub</title>
-    <link rel="stylesheet" href="../styles.css">
+    <title>Coordinator Pathway - RPO AI Acceleration</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../../shared/hub-button.css">
+    <link rel="stylesheet" href="../../shared/fonts.css">
+    <link rel="stylesheet" href="../../shared/scroll-to-top.css">
+    <link rel="stylesheet" href="../../shared/buttons.css">
+    <link rel="stylesheet" href="../css/pathways.css">
+    <link rel="stylesheet" href="../../rpo-training/css/style.css">
 </head>
-<body>
-    <div class="container">
-        <header>
-            <h1>🤝 Coordinator Learning Track</h1>
-            <p class="subtitle">Practical AI training for recruitment coordinators</p>
-        </header>
 
-        <div class="role-welcome">
-            <div class="welcome-card">
-                <h2>Welcome, Coordinator!</h2>
-                <p>As a recruitment coordinator, you'll benefit most from our <strong>Beginner Learning Path</strong>, which focuses on practical daily applications, communication enhancement, and workflow optimization.</p>
-            </div>
+<body class="text-gray-800">
 
-            <div class="recommended-modules">
-                <h3>🌟 Recommended Focus Areas</h3>
-                <div class="module-grid">
-                    <div class="module-card highlight">
-                        <h4>Communication Enhancement</h4>
-                        <p>Improve candidate and client communications with AI assistance</p>
-                    </div>
-                    <div class="module-card highlight">
-                        <h4>Scheduling & Organization</h4>
-                        <p>Streamline interview scheduling and candidate management</p>
-                    </div>
-                    <div class="module-card highlight">
-                        <h4>Administrative Automation</h4>
-                        <p>Automate routine tasks and improve workflow efficiency</p>
-                    </div>
+    <!-- Header -->
+    <header class="bg-white site-header sticky top-0 z-10">
+        <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+            <h1 id="header-title" class="google-sans text-2xl text-gray-700">RPO AI Acceleration Program</h1>
+            <a href="../../index.html" class="hub-button">Back To Hub</a>
+        </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="max-w-5xl mx-auto px-6 py-8">
+
+        <!-- Breadcrumb Navigation -->
+        <div class="breadcrumb-nav">
+            <a href="../index.html">Training Hub</a>
+            <span class="separator">&gt;</span>
+            <span>Coordinator Pathway</span>
+        </div>
+
+        <!-- Page Header -->
+        <div class="pathway-header">
+            <h1 class="google-sans text-4xl font-bold text-gray-800">⚙️ Coordinator Learning Pathway</h1>
+            <p class="mt-4 text-lg text-gray-600">Enhance your organizational skills with AI to streamline scheduling, improve communication, and automate administrative tasks.</p>
+        </div>
+
+        <!-- Learning Modules Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Core Modules</h2>
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <!-- Module 1 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-green-600">MODULE 1</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">AI-Powered Scheduling</h3>
+                    <p class="mt-2 text-gray-600">Learn to use AI tools to automate interview scheduling, manage calendars, and send reminders.</p>
+                </div>
+                <!-- Module 2 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-green-600">MODULE 2</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Enhanced Candidate Communication</h3>
+                    <p class="mt-2 text-gray-600">Use AI to draft clear and consistent communications, ensuring a positive candidate experience.</p>
+                </div>
+                <!-- Module 3 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-green-600">MODULE 3</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Administrative Automation</h3>
+                    <p class="mt-2 text-gray-600">Discover how to automate routine tasks like data entry, document preparation, and follow-ups.</p>
                 </div>
             </div>
+        </section>
 
-            <div class="pathway-redirect">
-                <h3>🚀 Ready to Coordinate?</h3>
-                <p>You'll be directed to the Beginner Learning Path with coordinator-specific examples and practical applications.</p>
-                <button onclick="startCoordinatorPath()" class="cta-button">Begin Coordinator Training</button>
+        <!-- Learning Objectives Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Learning Objectives</h2>
+            <ul class="list-disc list-inside space-y-2 text-gray-700">
+                <li>Reduce time spent on manual scheduling and administrative tasks.</li>
+                <li>Improve the quality and consistency of candidate communications.</li>
+                <li>Automate data entry to ensure accuracy and save time.</li>
+                <li>Enhance the overall efficiency of the recruitment process.</li>
+            </ul>
+        </section>
+
+        <!-- Resources Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Tools & Resources</h2>
+            <div class="grid md:grid-cols-2 gap-6">
+                <a href="#" class="resource-card bg-white p-4 rounded-lg border border-gray-200 hover:shadow-md transition-shadow">
+                    <h4 class="font-bold text-green-700">Scheduling Automation Cheatsheet</h4>
+                    <p class="text-sm text-gray-600">A guide to the best AI tools for automating recruitment coordination.</p>
+                </a>
+                <a href="#" class="resource-card bg-white p-4 rounded-lg border border-gray-200 hover:shadow-md transition-shadow">
+                    <h4 class="font-bold text-green-700">Communication Templates</h4>
+                    <p class="text-sm text-gray-600">A library of AI-generated templates for common coordinator communications.</p>
+                </a>
             </div>
-        </div>
-    </div>
+        </section>
 
-    <script>
-        function startCoordinatorPath() {
-            // Set role-specific context
-            localStorage.setItem('userRole', 'coordinator');
-            localStorage.setItem('roleSpecificFocus', JSON.stringify([
-                'communication-enhancement',
-                'scheduling-optimization',
-                'administrative-automation',
-                'candidate-experience'
-            ]));
-            
-            // Redirect to beginner path
-            window.location.href = 'beginner.html';
-        }
+    </main>
 
-        // Auto-redirect after 5 seconds if user doesn't click
-        setTimeout(() => {
-            startCoordinatorPath();
-        }, 5000);
-    </script>
+    <!-- Back to Top Button -->
+    <button id="back-to-top" class="back-to-top" title="Back to top" aria-label="Scroll to top">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6" /></svg>
+    </button>
+
+    <div id="footer-placeholder"></div>
+    <script src="../../shared/scripts/footer.js" defer></script>
+    <script src="../../shared/scripts/scroll-to-top.js" defer></script>
 </body>
 </html>

--- a/rpo-training/pathways/css/pathways.css
+++ b/rpo-training/pathways/css/pathways.css
@@ -1,0 +1,67 @@
+/* General Body Styles */
+body {
+    background-color: #f8f9fa;
+    color: #333;
+}
+
+/* Breadcrumb Navigation */
+.breadcrumb-nav {
+    margin-bottom: 2rem;
+    font-size: 0.9rem;
+}
+
+.breadcrumb-nav a {
+    color: #007bff;
+    text-decoration: none;
+    transition: color 0.3s;
+}
+
+.breadcrumb-nav a:hover {
+    color: #0056b3;
+}
+
+.breadcrumb-nav .separator {
+    margin: 0 0.5rem;
+    color: #6c757d;
+}
+
+/* Page Header */
+.pathway-header {
+    text-align: center;
+    margin-bottom: 3rem;
+    padding: 2rem 0;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.pathway-header h1 {
+    font-size: 2.5rem;
+    font-weight: 700;
+}
+
+.pathway-header p {
+    font-size: 1.2rem;
+    color: #6c757d;
+    max-width: 600px;
+    margin: 0.5rem auto 0;
+}
+
+/* Content Sections */
+.pathway-section {
+    margin-bottom: 3rem;
+}
+
+.pathway-section h2 {
+    font-size: 1.8rem;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+    border-bottom: 2px solid #007bff;
+    padding-bottom: 0.5rem;
+    display: inline-block;
+}
+
+/* Module Cards */
+.module-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+}

--- a/rpo-training/pathways/manager.html
+++ b/rpo-training/pathways/manager.html
@@ -1,69 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Manager Learning Track - RPO Training Hub</title>
-    <link rel="stylesheet" href="../styles.css">
+    <title>Manager Pathway - RPO AI Acceleration</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../../shared/hub-button.css">
+    <link rel="stylesheet" href="../../shared/fonts.css">
+    <link rel="stylesheet" href="../../shared/scroll-to-top.css">
+    <link rel="stylesheet" href="../../shared/buttons.css">
+    <link rel="stylesheet" href="../css/pathways.css">
+    <link rel="stylesheet" href="../../rpo-training/css/style.css">
 </head>
-<body>
-    <div class="container">
-        <header>
-            <h1>👔 Manager Learning Track</h1>
-            <p class="subtitle">Strategic AI leadership for recruitment managers</p>
-        </header>
 
-        <div class="role-welcome">
-            <div class="welcome-card">
-                <h2>Welcome, Manager!</h2>
-                <p>As a recruitment manager, you'll benefit most from our <strong>Advanced Learning Path</strong>, which covers strategic implementation, team leadership, and advanced AI integration for recruitment operations.</p>
-            </div>
+<body class="text-gray-800">
 
-            <div class="recommended-modules">
-                <h3>🌟 Recommended Focus Areas</h3>
-                <div class="module-grid">
-                    <div class="module-card highlight">
-                        <h4>Strategic AI Implementation</h4>
-                        <p>Learn to develop AI strategies and lead digital transformation initiatives</p>
-                    </div>
-                    <div class="module-card highlight">
-                        <h4>Team Training & Adoption</h4>
-                        <p>Master change management and team onboarding for AI tools</p>
-                    </div>
-                    <div class="module-card highlight">
-                        <h4>Performance Analytics</h4>
-                        <p>Use AI for recruitment metrics, reporting, and process optimization</p>
-                    </div>
+    <!-- Header -->
+    <header class="bg-white site-header sticky top-0 z-10">
+        <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+            <h1 id="header-title" class="google-sans text-2xl text-gray-700">RPO AI Acceleration Program</h1>
+            <a href="../../index.html" class="hub-button">Back To Hub</a>
+        </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="max-w-5xl mx-auto px-6 py-8">
+
+        <!-- Breadcrumb Navigation -->
+        <div class="breadcrumb-nav">
+            <a href="../index.html">Training Hub</a>
+            <span class="separator">&gt;</span>
+            <span>Manager Pathway</span>
+        </div>
+
+        <!-- Page Header -->
+        <div class="pathway-header">
+            <h1 class="google-sans text-4xl font-bold text-gray-800">📊 Manager Learning Pathway</h1>
+            <p class="mt-4 text-lg text-gray-600">Develop AI-driven strategies to lead your team, optimize workflows, and measure recruitment success.</p>
+        </div>
+
+        <!-- Learning Modules Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Core Modules</h2>
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <!-- Module 1 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-purple-600">MODULE 1</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Strategic AI Implementation</h3>
+                    <p class="mt-2 text-gray-600">Learn to develop an AI roadmap, identify high-impact use cases, and lead change within your team.</p>
+                </div>
+                <!-- Module 2 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-purple-600">MODULE 2</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Performance Analytics & Reporting</h3>
+                    <p class="mt-2 text-gray-600">Use AI to track recruitment KPIs, generate insightful reports, and forecast hiring trends.</p>
+                </div>
+                <!-- Module 3 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-purple-600">MODULE 3</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Team Training & AI Adoption</h3>
+                    <p class="mt-2 text-gray-600">Master techniques for training your team, driving AI adoption, and fostering a culture of innovation.</p>
                 </div>
             </div>
+        </section>
 
-            <div class="pathway-redirect">
-                <h3>🚀 Ready to Lead?</h3>
-                <p>You'll be directed to the Advanced Learning Path with management-focused content and leadership strategies.</p>
-                <button onclick="startManagerPath()" class="cta-button">Begin Manager Training</button>
+        <!-- Learning Objectives Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Learning Objectives</h2>
+            <ul class="list-disc list-inside space-y-2 text-gray-700">
+                <li>Develop a strategic plan for integrating AI into your team's workflows.</li>
+                <li>Analyze recruitment data to identify bottlenecks and opportunities.</li>
+                <li>Effectively manage change and encourage team-wide AI adoption.</li>
+                <li>Report on the ROI of AI initiatives to senior leadership.</li>
+            </ul>
+        </section>
+
+        <!-- Resources Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Tools & Resources</h2>
+            <div class="grid md:grid-cols-2 gap-6">
+                <a href="#" class="resource-card bg-white p-4 rounded-lg border border-gray-200 hover:shadow-md transition-shadow">
+                    <h4 class="font-bold text-purple-700">AI Strategy Template</h4>
+                    <p class="text-sm text-gray-600">A framework for planning and implementing AI projects in your recruitment team.</p>
+                </a>
+                <a href="#" class="resource-card bg-white p-4 rounded-lg border border-gray-200 hover:shadow-md transition-shadow">
+                    <h4 class="font-bold text-purple-700">Change Management Guide</h4>
+                    <p class="text-sm text-gray-600">A step-by-step guide to leading your team through the adoption of new AI tools.</p>
+                </a>
             </div>
-        </div>
-    </div>
+        </section>
 
-    <script>
-        function startManagerPath() {
-            // Set role-specific context
-            localStorage.setItem('userRole', 'manager');
-            localStorage.setItem('roleSpecificFocus', JSON.stringify([
-                'strategic-planning',
-                'team-leadership',
-                'performance-analytics',
-                'change-management'
-            ]));
-            
-            // Redirect to advanced path
-            window.location.href = 'advanced.html';
-        }
+    </main>
 
-        // Auto-redirect after 5 seconds if user doesn't click
-        setTimeout(() => {
-            startManagerPath();
-        }, 5000);
-    </script>
+    <!-- Back to Top Button -->
+    <button id="back-to-top" class="back-to-top" title="Back to top" aria-label="Scroll to top">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6" /></svg>
+    </button>
+
+    <div id="footer-placeholder"></div>
+    <script src="../../shared/scripts/footer.js" defer></script>
+    <script src="../../shared/scripts/scroll-to-top.js" defer></-script>
 </body>
 </html>

--- a/rpo-training/pathways/recruiter.html
+++ b/rpo-training/pathways/recruiter.html
@@ -1,69 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Recruiter Learning Track - RPO Training Hub</title>
-    <link rel="stylesheet" href="../styles.css">
+    <title>Recruiter Pathway - RPO AI Acceleration</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../../shared/hub-button.css">
+    <link rel="stylesheet" href="../../shared/fonts.css">
+    <link rel="stylesheet" href="../../shared/scroll-to-top.css">
+    <link rel="stylesheet" href="../../shared/buttons.css">
+    <link rel="stylesheet" href="../css/pathways.css">
+    <link rel="stylesheet" href="../../rpo-training/css/style.css">
 </head>
-<body>
-    <div class="container">
-        <header>
-            <h1>🎯 Recruiter Learning Track</h1>
-            <p class="subtitle">Specialized AI training for recruitment professionals</p>
-        </header>
 
-        <div class="role-welcome">
-            <div class="welcome-card">
-                <h2>Welcome, Recruiter!</h2>
-                <p>As a recruitment professional, you'll benefit most from our <strong>Intermediate Learning Path</strong>, which focuses on advanced prompting techniques and practical applications for candidate sourcing, screening, and engagement.</p>
-            </div>
+<body class="text-gray-800">
 
-            <div class="recommended-modules">
-                <h3>🌟 Recommended Focus Areas</h3>
-                <div class="module-grid">
-                    <div class="module-card highlight">
-                        <h4>Advanced Prompting Techniques</h4>
-                        <p>Master complex prompts for candidate evaluation and job description optimization</p>
-                    </div>
-                    <div class="module-card highlight">
-                        <h4>Candidate Sourcing with AI</h4>
-                        <p>Learn to create effective Boolean searches and candidate personas</p>
-                    </div>
-                    <div class="module-card highlight">
-                        <h4>Interview Question Generation</h4>
-                        <p>Generate role-specific, behavioral, and technical interview questions</p>
-                    </div>
+    <!-- Header -->
+    <header class="bg-white site-header sticky top-0 z-10">
+        <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+            <h1 id="header-title" class="google-sans text-2xl text-gray-700">RPO AI Acceleration Program</h1>
+            <a href="../../index.html" class="hub-button">Back To Hub</a>
+        </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="max-w-5xl mx-auto px-6 py-8">
+
+        <!-- Breadcrumb Navigation -->
+        <div class="breadcrumb-nav">
+            <a href="../index.html">Training Hub</a>
+            <span class="separator">&gt;</span>
+            <span>Recruiter Pathway</span>
+        </div>
+
+        <!-- Page Header -->
+        <div class="pathway-header">
+            <h1 class="google-sans text-4xl font-bold text-gray-800">👥 Recruiter Learning Pathway</h1>
+            <p class="mt-4 text-lg text-gray-600">Master AI-powered tools and techniques to source, engage, and evaluate top talent more effectively.</p>
+        </div>
+
+        <!-- Learning Modules Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Core Modules</h2>
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <!-- Module 1 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-blue-600">MODULE 1</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">AI-Enhanced Sourcing</h3>
+                    <p class="mt-2 text-gray-600">Learn to generate advanced Boolean strings, identify hidden talent pools, and automate candidate searches.</p>
+                </div>
+                <!-- Module 2 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-blue-600">MODULE 2</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Intelligent Candidate Outreach</h3>
+                    <p class="mt-2 text-gray-600">Craft personalized, high-impact outreach messages that boost response rates and build rapport.</p>
+                </div>
+                <!-- Module 3 -->
+                <div class="module-card">
+                    <p class="text-sm font-semibold text-blue-600">MODULE 3</p>
+                    <h3 class="google-sans text-xl font-bold mt-2">Efficient Screening & Evaluation</h3>
+                    <p class="mt-2 text-gray-600">Use AI to screen resumes, generate interview questions, and summarize candidate qualifications.</p>
                 </div>
             </div>
+        </section>
 
-            <div class="pathway-redirect">
-                <h3>🚀 Ready to Start?</h3>
-                <p>You'll be directed to the Intermediate Learning Path with recruiter-specific examples and use cases.</p>
-                <button onclick="startRecruiterPath()" class="cta-button">Begin Recruiter Training</button>
+        <!-- Learning Objectives Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Learning Objectives</h2>
+            <ul class="list-disc list-inside space-y-2 text-gray-700">
+                <li>Automate the creation of complex search strings for various roles.</li>
+                <li>Personalize outreach campaigns at scale to improve engagement.</li>
+                <li>Reduce time-to-fill by streamlining the resume screening process.</li>
+                <li>Develop data-driven insights into your recruitment funnel.</li>
+            </ul>
+        </section>
+
+        <!-- Resources Section -->
+        <section class="pathway-section">
+            <h2 class="google-sans text-2xl font-bold text-gray-800 mb-6">Tools & Resources</h2>
+            <div class="grid md:grid-cols-2 gap-6">
+                <a href="#" class="resource-card bg-white p-4 rounded-lg border border-gray-200 hover:shadow-md transition-shadow">
+                    <h4 class="font-bold text-blue-700">Prompt Library for Recruiters</h4>
+                    <p class="text-sm text-gray-600">A collection of ready-to-use prompts for common recruiting tasks.</p>
+                </a>
+                <a href="#" class="resource-card bg-white p-4 rounded-lg border border-gray-200 hover:shadow-md transition-shadow">
+                    <h4 class="font-bold text-blue-700">AI Sourcing Cheatsheet</h4>
+                    <p class="text-sm text-gray-600">A quick-reference guide for AI-powered sourcing techniques.</p>
+                </a>
             </div>
-        </div>
-    </div>
+        </section>
 
-    <script>
-        function startRecruiterPath() {
-            // Set role-specific context
-            localStorage.setItem('userRole', 'recruiter');
-            localStorage.setItem('roleSpecificFocus', JSON.stringify([
-                'candidate-sourcing',
-                'interview-preparation', 
-                'job-description-optimization',
-                'candidate-evaluation'
-            ]));
-            
-            // Redirect to intermediate path
-            window.location.href = 'intermediate.html';
-        }
+    </main>
 
-        // Auto-redirect after 3 seconds if user doesn't click
-        setTimeout(() => {
-            startRecruiterPath();
-        }, 5000);
-    </script>
+    <!-- Back to Top Button -->
+    <button id="back-to-top" class="back-to-top" title="Back to top" aria-label="Scroll to top">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6" /></svg>
+    </button>
+
+    <div id="footer-placeholder"></div>
+    <script src="../../shared/scripts/footer.js" defer></script>
+    <script src="../../shared/scripts/scroll-to-top.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Rebuilt the four role-based pathway pages (recruiter, manager, coordinator, analyst) to be fully functional and consistent with the main site design.

- Created a shared CSS file for pathway-specific styles.
- Developed a standard HTML template based on the main site, including a shared header, footer, and navigation.
- Overhauled each of the four pathway pages with a structured layout, responsive design, and role-specific placeholder content.
- Added a README.md file in the pathways directory to document the new structure and provide instructions for future maintenance.
- Removed the previous redirect-based implementation in favor of complete, static content pages.